### PR TITLE
Inject GA snippet and switch to SCP deploy

### DIFF
--- a/.github/workflows/live_deployment.yml
+++ b/.github/workflows/live_deployment.yml
@@ -22,15 +22,8 @@ jobs:
           GA_SNIPPET='<!-- Google tag (gtag.js) -->\n<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8ER3NY2XD"></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag("js", new Date());\n  gtag("config", "G-N8ER3NY2XD");\n</script>'
           find . -name "*.html" | xargs sed -i "s|</head>|${GA_SNIPPET}\n</head>|g"
 
-      - name: Display secrets
-        run: |
-          echo "Deploying to production..."
-          echo ${{ secrets.SSH_HOST }}
-          echo ${{ secrets.SSH_USERNAME || 'ubuntu' }}
-          echo ${{ secrets.SSH_PORT || 22 }}
-
       - name: Copy files to server via SCP
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME || 'ubuntu' }}

--- a/.github/workflows/live_deployment.yml
+++ b/.github/workflows/live_deployment.yml
@@ -16,7 +16,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
+      - name: Inject Google Analytics
+        run: |
+          GA_SNIPPET='<!-- Google tag (gtag.js) -->\n<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8ER3NY2XD"></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag("js", new Date());\n  gtag("config", "G-N8ER3NY2XD");\n</script>'
+          find . -name "*.html" | xargs sed -i "s|</head>|${GA_SNIPPET}\n</head>|g"
+
       - name: Display secrets
         run: |
           echo "Deploying to production..."
@@ -24,15 +29,13 @@ jobs:
           echo ${{ secrets.SSH_USERNAME || 'ubuntu' }}
           echo ${{ secrets.SSH_PORT || 22 }}
 
-      - name: Execute deployment commands
-        uses: appleboy/ssh-action@v1.2.0
+      - name: Copy files to server via SCP
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME || 'ubuntu' }}
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || 22 }}
-          debug: true
-          script: |
-            whoami
-            cd /var/www/html/fleetyes.com/htdocs
-            sudo git pull origin main
+          source: "."
+          target: "/var/www/html/fleetyes.com/htdocs"
+          overwrite: true


### PR DESCRIPTION
Add a workflow step that injects a Google Analytics gtag snippet (G-N8ER3NY2XD) into all HTML files during the CI run. Replace the previous remote SSH git-pull deployment with appleboy/scp-action to copy the repository contents to /var/www/html/fleetyes.com/htdocs and overwrite existing files. This simplifies deployment by pushing built files directly and ensures GA is included in served pages.