### PR TITLE
Adjust footer layout and address formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,21 +451,19 @@
   <footer id="footer" class="footer">
     <div class="container footer-top">
       <div class="row gy-4">
-        <div class="col-lg-8 col-md-6 footer-about">
+        <div class="col-lg-9 col-md-6 footer-about">
           <a href="/" class="logo d-flex align-items-center">
             <img src="assets/img/fleetyes.svg" alt="FleetYes">
             <span class="sitename">FleetYes</span>
           </a>
           <div class="footer-contact pt-3"></div>
         </div>
-        <div class="col-lg-2 col-md-6">
+        <div class="col-lg-3 col-md-6">
           <h4>Location</h4>
-          <p>Suite RA01<br>
-  195–197 Wood Street<br>
-  London E17 3NU<br>
-  United Kingdom</p>
+          <p>Suite RA01, 195–197 Wood Street<br>
+  London E17 3NU, United Kingdom</p>
         </div>
-        <div class="col-lg-2 col-md-6">
+        <div class="col-lg-2 col-md-6 d-none">
           <h4>Contact</h4>
           <p><strong>Phone:</strong> <span>+44 20 3290 3256</span></p>
           <p><strong>Email:</strong> <span>sales@fleetyes.com</span></p>


### PR DESCRIPTION
Rebalanced footer grid by changing the about column from col-lg-8 to col-lg-9 and the location column from col-lg-2 to col-lg-3. Condensed the multi-line address into a single paragraph with comma separators. Added d-none to the contact column to hide the contact block.