### PR TITLE
Make mobile nav toggle black when scrolled

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -854,6 +854,10 @@ h6 {
     z-index: 9999;
   }
 
+  body.scrolled i.mobile-nav-toggle {
+    color: #000;
+  }
+
   .mobile-nav-active .navmenu {
     position: fixed;
     overflow: hidden;

--- a/extension-privacy.html
+++ b/extension-privacy.html
@@ -40,6 +40,63 @@
   </head>
 
   <body class="index-page extension-privacy">
+    <!-- VASP Amazon AFP Banner -->
+    <div id="vasp-banner" class="vasp-banner">
+      <div class="vasp-banner-inner">
+        <div class="vasp-carousel" id="vasp-carousel" aria-live="polite">
+          <div class="vasp-track" id="vasp-track">
+            <!-- Slide 1: VAS Provider -->
+            <div class="vasp-slide">
+              <div class="vasp-banner-left">
+                <div class="vasp-badge">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" fill="currentColor"/>
+                  </svg>
+                  <span>Official VAS Provider</span>
+                </div>
+                <span class="vasp-headline">Officially recognised as an <span class="vasp-amazon">Amazon AFP</span> <strong>Value Added Service (VAS) Provider</strong></span>
+              </div>
+              <div class="vasp-banner-right">
+                <a href="/vas-provider" class="vasp-learn-more" aria-label="Learn more about FleetYes as an Amazon AFP VAS Provider">
+                  Learn More
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+              </div>
+            </div>
+
+            <!-- Slide 2: AFF Event -->
+            <div class="vasp-slide">
+              <div class="vasp-banner-left">
+                <div class="vasp-badge">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                    <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                  <span>AFF Event 2026</span>
+                </div>
+                <span class="vasp-headline">Join us at the <strong>AFF Event 2026</strong> <span class="vasp-event-date">Rome · May 26–28</span></span>
+              </div>
+              <div class="vasp-banner-right">
+                <a href="/aff-event" class="vasp-learn-more" aria-label="Learn more about the AFF Event 2026">
+                  Learn More
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Close -->
+        <button class="vasp-close" id="vasp-close-btn" aria-label="Close banner">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+
     <header id="header" class="header d-flex align-items-center fixed-top">
       <div
         class="container-fluid container-xl position-relative d-flex align-items-center"
@@ -170,5 +227,72 @@ cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palet
 
     <!-- Main JS File -->
     <script src="assets/js/main.js"></script>
+
+  <!-- VASP Banner Script -->
+  <script>
+    (function () {
+      var banner   = document.getElementById('vasp-banner');
+      var carousel = document.getElementById('vasp-carousel');
+      var track    = document.getElementById('vasp-track');
+      var closeBtn = document.getElementById('vasp-close-btn');
+      var slides   = track ? track.querySelectorAll('.vasp-slide') : [];
+      var total    = slides.length;
+      var current  = 0;
+      var timer    = null;
+
+      function setSlideWidths() {
+        if (!carousel || !track) return;
+        var w = carousel.offsetWidth;
+        for (var i = 0; i < slides.length; i++) {
+          slides[i].style.width = w + 'px';
+        }
+      }
+
+      function goTo(index) {
+        if (!carousel || !track) return;
+        current = ((index % total) + total) % total;
+        var w = carousel.offsetWidth;
+        track.style.transform = 'translateX(-' + (current * w) + 'px)';
+      }
+
+      function next() { goTo(current + 1); }
+
+      function startAuto() { timer = setInterval(next, 4000); }
+      function stopAuto()  { clearInterval(timer); }
+
+      if (closeBtn) {
+        closeBtn.addEventListener('click', function () {
+          stopAuto();
+          banner.style.transition = 'max-height 0.35s ease, opacity 0.3s ease';
+          banner.style.opacity = '0';
+          banner.style.maxHeight = '0';
+          setTimeout(function () {
+            banner.style.display = 'none';
+            document.documentElement.style.setProperty('--vasp-banner-height', '0px');
+          }, 350);
+        });
+      }
+
+      if (banner) {
+        banner.addEventListener('mouseenter', stopAuto);
+        banner.addEventListener('mouseleave', startAuto);
+      }
+
+      function syncBannerHeight() {
+        var h = (banner && banner.style.display !== 'none') ? banner.offsetHeight : 0;
+        document.documentElement.style.setProperty('--vasp-banner-height', (h || 56) + 'px');
+      }
+
+      window.addEventListener('resize', function () {
+        setSlideWidths();
+        goTo(current);
+        syncBannerHeight();
+      });
+
+      setSlideWidths();
+      startAuto();
+      syncBannerHeight();
+    })();
+  </script>
   </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -40,6 +40,63 @@
   </head>
 
   <body class="index-page privacy-policy">
+    <!-- VASP Amazon AFP Banner -->
+    <div id="vasp-banner" class="vasp-banner">
+      <div class="vasp-banner-inner">
+        <div class="vasp-carousel" id="vasp-carousel" aria-live="polite">
+          <div class="vasp-track" id="vasp-track">
+            <!-- Slide 1: VAS Provider -->
+            <div class="vasp-slide">
+              <div class="vasp-banner-left">
+                <div class="vasp-badge">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" fill="currentColor"/>
+                  </svg>
+                  <span>Official VAS Provider</span>
+                </div>
+                <span class="vasp-headline">Officially recognised as an <span class="vasp-amazon">Amazon AFP</span> <strong>Value Added Service (VAS) Provider</strong></span>
+              </div>
+              <div class="vasp-banner-right">
+                <a href="/vas-provider" class="vasp-learn-more" aria-label="Learn more about FleetYes as an Amazon AFP VAS Provider">
+                  Learn More
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+              </div>
+            </div>
+
+            <!-- Slide 2: AFF Event -->
+            <div class="vasp-slide">
+              <div class="vasp-banner-left">
+                <div class="vasp-badge">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                    <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                  <span>AFF Event 2026</span>
+                </div>
+                <span class="vasp-headline">Join us at the <strong>AFF Event 2026</strong> <span class="vasp-event-date">Rome · May 26–28</span></span>
+              </div>
+              <div class="vasp-banner-right">
+                <a href="/aff-event" class="vasp-learn-more" aria-label="Learn more about the AFF Event 2026">
+                  Learn More
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Close -->
+        <button class="vasp-close" id="vasp-close-btn" aria-label="Close banner">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+
     <header id="header" class="header d-flex align-items-center fixed-top">
       <div
         class="container-fluid container-xl position-relative d-flex align-items-center"
@@ -206,5 +263,72 @@ cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palet
 
     <!-- Main JS File -->
     <script src="assets/js/main.js"></script>
+
+  <!-- VASP Banner Script -->
+  <script>
+    (function () {
+      var banner   = document.getElementById('vasp-banner');
+      var carousel = document.getElementById('vasp-carousel');
+      var track    = document.getElementById('vasp-track');
+      var closeBtn = document.getElementById('vasp-close-btn');
+      var slides   = track ? track.querySelectorAll('.vasp-slide') : [];
+      var total    = slides.length;
+      var current  = 0;
+      var timer    = null;
+
+      function setSlideWidths() {
+        if (!carousel || !track) return;
+        var w = carousel.offsetWidth;
+        for (var i = 0; i < slides.length; i++) {
+          slides[i].style.width = w + 'px';
+        }
+      }
+
+      function goTo(index) {
+        if (!carousel || !track) return;
+        current = ((index % total) + total) % total;
+        var w = carousel.offsetWidth;
+        track.style.transform = 'translateX(-' + (current * w) + 'px)';
+      }
+
+      function next() { goTo(current + 1); }
+
+      function startAuto() { timer = setInterval(next, 4000); }
+      function stopAuto()  { clearInterval(timer); }
+
+      if (closeBtn) {
+        closeBtn.addEventListener('click', function () {
+          stopAuto();
+          banner.style.transition = 'max-height 0.35s ease, opacity 0.3s ease';
+          banner.style.opacity = '0';
+          banner.style.maxHeight = '0';
+          setTimeout(function () {
+            banner.style.display = 'none';
+            document.documentElement.style.setProperty('--vasp-banner-height', '0px');
+          }, 350);
+        });
+      }
+
+      if (banner) {
+        banner.addEventListener('mouseenter', stopAuto);
+        banner.addEventListener('mouseleave', startAuto);
+      }
+
+      function syncBannerHeight() {
+        var h = (banner && banner.style.display !== 'none') ? banner.offsetHeight : 0;
+        document.documentElement.style.setProperty('--vasp-banner-height', (h || 56) + 'px');
+      }
+
+      window.addEventListener('resize', function () {
+        setSlideWidths();
+        goTo(current);
+        syncBannerHeight();
+      });
+
+      setSlideWidths();
+      startAuto();
+      syncBannerHeight();
+    })();
+  </script>
   </body>
 </html>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -31,6 +31,63 @@
 </head>
 
 <body class="terms-and-conditions index-page">
+  <!-- VASP Amazon AFP Banner -->
+  <div id="vasp-banner" class="vasp-banner">
+    <div class="vasp-banner-inner">
+      <div class="vasp-carousel" id="vasp-carousel" aria-live="polite">
+        <div class="vasp-track" id="vasp-track">
+          <!-- Slide 1: VAS Provider -->
+          <div class="vasp-slide">
+            <div class="vasp-banner-left">
+              <div class="vasp-badge">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" fill="currentColor"/>
+                </svg>
+                <span>Official VAS Provider</span>
+              </div>
+              <span class="vasp-headline">Officially recognised as an <span class="vasp-amazon">Amazon AFP</span> <strong>Value Added Service (VAS) Provider</strong></span>
+            </div>
+            <div class="vasp-banner-right">
+              <a href="/vas-provider" class="vasp-learn-more" aria-label="Learn more about FleetYes as an Amazon AFP VAS Provider">
+                Learn More
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </a>
+            </div>
+          </div>
+
+          <!-- Slide 2: AFF Event -->
+          <div class="vasp-slide">
+            <div class="vasp-banner-left">
+              <div class="vasp-badge">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                  <line x1="16" y1="2" x2="16" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  <line x1="8" y1="2" x2="8" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  <line x1="3" y1="10" x2="21" y2="10" stroke="currentColor" stroke-width="2"/>
+                </svg>
+                <span>AFF Event 2026</span>
+              </div>
+              <span class="vasp-headline">Join us at the <strong>AFF Event 2026</strong> <span class="vasp-event-date">Rome · May 26–28</span></span>
+            </div>
+            <div class="vasp-banner-right">
+              <a href="/aff-event" class="vasp-learn-more" aria-label="Learn more about the AFF Event 2026">
+                Learn More
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12H19M13 6L19 12L13 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Close -->
+      <button class="vasp-close" id="vasp-close-btn" aria-label="Close banner">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
   <header id="header" class="header d-flex align-items-center fixed-top">
     <div class="container-fluid container-xl position-relative d-flex align-items-center">
       <a href="/" class="logo d-flex align-items-center me-auto">
@@ -200,6 +257,73 @@
 
   <!-- Main JS File -->
   <script src="assets/js/main.js"></script>
+
+  <!-- VASP Banner Script -->
+  <script>
+    (function () {
+      var banner   = document.getElementById('vasp-banner');
+      var carousel = document.getElementById('vasp-carousel');
+      var track    = document.getElementById('vasp-track');
+      var closeBtn = document.getElementById('vasp-close-btn');
+      var slides   = track ? track.querySelectorAll('.vasp-slide') : [];
+      var total    = slides.length;
+      var current  = 0;
+      var timer    = null;
+
+      function setSlideWidths() {
+        if (!carousel || !track) return;
+        var w = carousel.offsetWidth;
+        for (var i = 0; i < slides.length; i++) {
+          slides[i].style.width = w + 'px';
+        }
+      }
+
+      function goTo(index) {
+        if (!carousel || !track) return;
+        current = ((index % total) + total) % total;
+        var w = carousel.offsetWidth;
+        track.style.transform = 'translateX(-' + (current * w) + 'px)';
+      }
+
+      function next() { goTo(current + 1); }
+
+      function startAuto() { timer = setInterval(next, 4000); }
+      function stopAuto()  { clearInterval(timer); }
+
+      if (closeBtn) {
+        closeBtn.addEventListener('click', function () {
+          stopAuto();
+          banner.style.transition = 'max-height 0.35s ease, opacity 0.3s ease';
+          banner.style.opacity = '0';
+          banner.style.maxHeight = '0';
+          setTimeout(function () {
+            banner.style.display = 'none';
+            document.documentElement.style.setProperty('--vasp-banner-height', '0px');
+          }, 350);
+        });
+      }
+
+      if (banner) {
+        banner.addEventListener('mouseenter', stopAuto);
+        banner.addEventListener('mouseleave', startAuto);
+      }
+
+      function syncBannerHeight() {
+        var h = (banner && banner.style.display !== 'none') ? banner.offsetHeight : 0;
+        document.documentElement.style.setProperty('--vasp-banner-height', (h || 56) + 'px');
+      }
+
+      window.addEventListener('resize', function () {
+        setSlideWidths();
+        goTo(current);
+        syncBannerHeight();
+      });
+
+      setSlideWidths();
+      startAuto();
+      syncBannerHeight();
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Add a CSS rule in assets/css/main.css to set the mobile nav toggle icon color to #000 when the body has the .scrolled class. This improves contrast/visibility of the toggle icon after the page is scrolled.