### PR TITLE
Remove 'View All Features' block from features

### DIFF
--- a/feature/ai-receipt-recognition.html
+++ b/feature/ai-receipt-recognition.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/background-location-tracking.html
+++ b/feature/background-location-tracking.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/biometric-secure-authentication.html
+++ b/feature/biometric-secure-authentication.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/calendar-scheduling.html
+++ b/feature/calendar-scheduling.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/dark-mode-customisable-themes.html
+++ b/feature/dark-mode-customisable-themes.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/driver-operations.html
+++ b/feature/driver-operations.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/driver-profile-documents.html
+++ b/feature/driver-profile-documents.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/expense-receipt-management.html
+++ b/feature/expense-receipt-management.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/feature-template.html
+++ b/feature/feature-template.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/fleetbase-sdk.html
+++ b/feature/fleetbase-sdk.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/geolocation-services.html
+++ b/feature/geolocation-services.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/google-maps-navigation-apis.html
+++ b/feature/google-maps-navigation-apis.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/gps-navigation-route-tracking.html
+++ b/feature/gps-navigation-route-tracking.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/image-processing.html
+++ b/feature/image-processing.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/internationalisation-localisation.html
+++ b/feature/internationalisation-localisation.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/issue-reporting.html
+++ b/feature/issue-reporting.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/ml-kit-text-recognition.html
+++ b/feature/ml-kit-text-recognition.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/multi-instance-deep-linking.html
+++ b/feature/multi-instance-deep-linking.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/offline-first-architecture.html
+++ b/feature/offline-first-architecture.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/performance-tracking-earnings.html
+++ b/feature/performance-tracking-earnings.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/proof-of-delivery.html
+++ b/feature/proof-of-delivery.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/push-notification-services.html
+++ b/feature/push-notification-services.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/push-notifications-real-time-updates.html
+++ b/feature/push-notifications-real-time-updates.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/real-time-chat-communication.html
+++ b/feature/real-time-chat-communication.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/real-time-order-management.html
+++ b/feature/real-time-order-management.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/responsive-mobile-ui.html
+++ b/feature/responsive-mobile-ui.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/shift-leave-management.html
+++ b/feature/shift-leave-management.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/training-compliance.html
+++ b/feature/training-compliance.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">

--- a/feature/websocket-socketcluster.html
+++ b/feature/websocket-socketcluster.html
@@ -800,14 +800,6 @@
       </div>
     </section>
 
-    <!-- View All Features Section -->
-    <div class="container text-center" data-aos="fade-up" data-aos-delay="100">
-      <a href="/features" class="read-more" style="margin-top: 40px;">
-        <span>View All Features</span>
-        <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-
     <!-- Final CTA Section -->
     <section class="cta-section-bottom" data-aos="fade-up">
       <div class="container">


### PR DESCRIPTION
Deleted the duplicated "View All Features" CTA section from multiple individual feature HTML pages to reduce redundancy and keep the final CTA section as the single navigation point. Applied the change across 29 feature pages for consistency and cleaner markup.