### PR TITLE
Set breadcrumb spacer color to white

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1159,6 +1159,10 @@ h6 {
   color: color-mix(in srgb, var(--default-color), transparent 70%);
 }
 
+.breadcrumb-nav span.mx-2 {
+  color: #fff;
+}
+
 /*--------------------------------------------------------------
 # Global Sections
 --------------------------------------------------------------*/


### PR DESCRIPTION
Add CSS rule in assets/css/main.css to force .breadcrumb-nav span.mx-2 to color #fff so breadcrumb separators render white (improves contrast on dark backgrounds).