### PR TITLE
Remove two feature cards from features page

### DIFF
--- a/features.html
+++ b/features.html
@@ -294,17 +294,6 @@
             </div>
           </a>
 
-          <a href="feature/responsive-mobile-ui" class="col-md-6 col-xl-3" style="text-decoration: none;">
-            <div class="feature-card" style="background-image: url('assets/img/features/responsive-mobile-ui.webp')";">
-              <div class="overlay"></div>
-              <div class="feature-card-content">
-                <i class="bi-phone feature-icon"></i>
-                <h3>Responsive Mobile UI</h3>
-                <p>Feel the difference-fast, intuitive, built for how you actually use your phone in the field</p>
-              </div>
-            </div>
-          </a>
-
           <a href="feature/shift-leave-management" class="col-md-6 col-xl-3" style="text-decoration: none;">
             <div class="feature-card" style="background-image: url('assets/img/features/shift-leave-management.webp')";">
               <div class="overlay"></div>
@@ -478,19 +467,6 @@
                 <i class="bi-calendar-event feature-icon"></i>
                 <h3>Calendar & Scheduling Integration</h3>
                 <p>Your schedule at a glance-visual calendar makes planning intuitive and conflict-proof</p>
-              </div>
-            </div>
-          </a>
-
-         
-
-          <a href="feature/geolocation-services" class="col-md-6 col-xl-3" style="text-decoration: none;">
-            <div class="feature-card" style="background-image: url('assets/img/features/geolocation-services.webp')";">
-              <div class="overlay"></div>
-              <div class="feature-card-content">
-                <i class="bi-pin-map feature-icon"></i>
-                <h3>Geolocation Services</h3>
-                <p>Precise GPS everywhere, all day-battery-smart tracking that never stops, never drains</p>
               </div>
             </div>
           </a>


### PR DESCRIPTION
Delete the HTML blocks for the "Responsive Mobile UI" and "Geolocation Services" feature cards from features.html. This removes their anchor blocks, background images, icons, and descriptive text to clean up the features list (reflecting that these features were retired/removed from the public feature set).