### PR TITLE
Fix: Update AFP portal link URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
               <div class="card col-12 col-md-6 p-2 p-md-3 p-xl-4 shadow-sm text-center" style="backdrop-filter: blur(8px); background: rgba(255, 255, 255, 0.15); border: 1px solid rgba(255, 255, 255, 0.3);">
                 <h4 class="text-white mb-3">Amazon Freight Partners</h4>
                 <p class="text-white mb-3">Manage freight workflows, delivery data, and operational reporting with faster processing and fewer manual errors.</p>
-                <a href="https://afp.fleetyes.com" target="_blank" rel="noopener" class="btn btn-light w-100 mb-3">
+                <a href="https://afp-dashboard.fleetyes.com/" target="_blank" rel="noopener" class="btn btn-light w-100 mb-3">
                   <i class="bi bi-truck me-2"></i> Access AFP Portal
                 </a>
                 <a href="https://afp.fleetyes.com/onboard" target="_blank" rel="noopener" class="btn btn-outline-light w-100 mb-3">


### PR DESCRIPTION
Change the Amazon Freight Partners link in index.html from https://afp.fleetyes.com to https://afp-dashboard.fleetyes.com/ so the "Access AFP Portal" button points to the new dashboard subdomain (includes trailing slash).