### PR TITLE
Bump year to 2026; refactor AFF styles

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -51,4 +51,4 @@ FleetYes offers innovative transport management software to streamline logistics
 
 ## License
 
-&copy; 2025 FleetYes. All rights reserved.
+&copy; 2026 FleetYes. All rights reserved.

--- a/aff-event.html
+++ b/aff-event.html
@@ -443,7 +443,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/aff.html
+++ b/aff.html
@@ -31,16 +31,12 @@
       --aff-green-lt:   #3e9560;
       --aff-green-pale: #eaf4ee;
       --aff-dark:       #0e1b16;
-      --aff-text:       #2c3a33;
-      --aff-muted:      #6b7872;
       --aff-border:     #e4e8e6;
       --aff-bg-soft:    #f5f6f5;
     }
 
-    body.aff-page {
-      font-family: 'Open Sans', sans-serif;
-      color: var(--aff-text);
-    }
+    /* AFF page uses Marcellus across body copy as well as headings */
+    body.aff-page { font-family: var(--heading-font); }
 
     /* No top padding — hero sits behind transparent header */
     .aff-page-wrap { padding-top: 0; }
@@ -137,7 +133,7 @@
       margin-bottom: 28px;
     }
     .aff-hero h1 {
-      font-family: 'Marcellus', serif;
+      font-family: var(--heading-font);
       font-size: 54px;
       line-height: 1.05;
       color: #fff;
@@ -176,6 +172,7 @@
       max-width: 460px;
       color: #cbd2cf;
       font-size: 15px;
+      font-weight: 700;
       line-height: 1.7;
       margin-bottom: 32px;
     }
@@ -230,7 +227,7 @@
       pointer-events: none;
     }
     .aff-hero-watermark .aff-wm-title {
-      font-family: 'Marcellus', serif;
+      font-family: var(--heading-font);
       font-size: 84px;
       letter-spacing: 0.04em;
       color: rgba(255,255,255,0.92);
@@ -265,10 +262,11 @@
       margin-bottom: 16px;
     }
     .aff-about h2 {
-      font-family: 'Marcellus', serif;
-      font-size: 36px;
+      font-family: var(--heading-font);
+      font-size: 32px;
+      font-weight: 700;
       line-height: 1.2;
-      color: var(--aff-dark);
+      color: var(--heading-color);
       margin-bottom: 24px;
       position: relative;
       padding-bottom: 14px;
@@ -282,9 +280,9 @@
       margin-top: 18px;
     }
     .aff-about p {
-      font-size: 14.5px;
+      font-size: 15px;
       line-height: 1.8;
-      color: var(--aff-muted);
+      color: var(--default-color);
       margin-bottom: 16px;
     }
 
@@ -314,7 +312,7 @@
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
-      color: var(--aff-muted);
+      color: var(--default-color);
     }
     .aff-info-icon svg { width: 22px; height: 22px; }
     .aff-info-body { flex: 1; min-width: 0; }
@@ -327,16 +325,16 @@
       margin-bottom: 4px;
     }
     .aff-info-title {
-      font-family: 'Marcellus', serif;
-      font-size: 19px;
-      color: var(--aff-dark);
+      font-family: var(--heading-font);
+      font-size: 20px;
+      color: var(--heading-color);
       margin-bottom: 6px;
       font-weight: 600;
     }
     .aff-info-desc {
-      font-size: 13.5px;
-      line-height: 1.65;
-      color: var(--aff-muted);
+      font-size: 14px;
+      line-height: 1.7;
+      color: var(--default-color);
       margin: 0;
     }
 
@@ -370,9 +368,10 @@
       margin-bottom: 14px;
     }
     .aff-gift-card h2 {
-      font-family: 'Marcellus', serif;
-      font-size: 30px;
-      color: var(--aff-dark);
+      font-family: var(--heading-font);
+      font-size: 32px;
+      font-weight: 700;
+      color: var(--heading-color);
       line-height: 1.3;
       margin-bottom: 20px;
       position: relative;
@@ -387,9 +386,9 @@
       margin: 18px auto 0;
     }
     .aff-gift-card p {
-      font-size: 14.5px;
+      font-size: 15px;
       line-height: 1.75;
-      color: var(--aff-muted);
+      color: var(--default-color);
       margin-bottom: 16px;
     }
     .aff-gift-card p:last-child { margin-bottom: 0; }
@@ -420,16 +419,17 @@
     }
     .aff-planning-card .aff-eyebrow { color: var(--aff-green); margin-bottom: 14px; }
     .aff-planning-card h2 {
-      font-family: 'Marcellus', serif;
+      font-family: var(--heading-font);
       font-size: 28px;
-      color: var(--aff-dark);
+      font-weight: 700;
+      color: var(--heading-color);
       margin-bottom: 18px;
       line-height: 1.25;
     }
     .aff-planning-card p {
-      font-size: 14.5px;
+      font-size: 15px;
       line-height: 1.75;
-      color: var(--aff-muted);
+      color: var(--default-color);
       margin-bottom: 26px;
     }
     .aff-planning-actions {
@@ -442,7 +442,7 @@
       align-items: center;
       gap: 8px;
       background: #fff;
-      color: var(--aff-dark) !important;
+      color: var(--heading-color) !important;
       border: 1.5px solid var(--aff-border);
       font-size: 14px;
       font-weight: 600;
@@ -462,15 +462,16 @@
       background: #fff;
     }
     .aff-contact-info h2 {
-      font-family: 'Marcellus', serif;
+      font-family: var(--heading-font);
       font-size: 32px;
-      color: var(--aff-dark);
+      font-weight: 700;
+      color: var(--heading-color);
       margin-bottom: 16px;
       line-height: 1.25;
     }
     .aff-contact-info > p {
-      font-size: 14.5px;
-      color: var(--aff-muted);
+      font-size: 15px;
+      color: var(--default-color);
       line-height: 1.7;
       margin-bottom: 28px;
     }
@@ -480,9 +481,9 @@
       align-items: flex-start;
       gap: 14px;
       padding: 12px 0;
-      font-size: 14px;
-      color: var(--aff-text);
-      line-height: 1.55;
+      font-size: 15px;
+      color: var(--default-color);
+      line-height: 1.6;
     }
     .aff-checklist .check-ico {
       width: 32px;
@@ -493,7 +494,7 @@
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
-      color: var(--aff-text);
+      color: var(--default-color);
     }
     .aff-checklist .check-ico svg { width: 16px; height: 16px; }
 
@@ -509,7 +510,7 @@
       border-radius: 10px;
       padding: 14px 16px;
       font-size: 14px;
-      color: var(--aff-text);
+      color: var(--default-color);
       transition: border-color .2s, box-shadow .2s;
     }
     .aff-form .form-control::placeholder {
@@ -643,7 +644,7 @@
         </ul>
         <i class="mobile-nav-toggle d-xl-none bi bi-list"></i>
       </nav>
-      <a href="/#contact" class="aff-book-demo d-none d-md-inline-flex">Book a Demo</a>
+      <a href="#book" class="aff-book-demo d-none d-md-inline-flex">Book a Demo</a>
     </div>
   </header>
   <!-- /Site Header -->
@@ -773,9 +774,9 @@
           </div>
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
             <div class="aff-planning-card">
-              <div class="aff-eyebrow">See You at AFF 2026</div>
-              <h2>Explore FleetYes at AFF 2026</h2>
-              <p>If you're attending AFF 2026, schedule time with the FleetYes team to discuss your operational challenges and see how our platform helps logistics operators improve visibility, reduce delays, and manage delivery operations more efficiently.</p>
+              <div class="aff-eyebrow">MEET US AT AFF 2026</div>
+              <h2>Let’s talk fleet operations</h2>
+              <p>Heading to Rome for AFF 2026? We would be delighted to sit down with you. Schedule a brief chat with the FleetYes team to discuss your day-to-day operational hurdles, and let's explore how our platform can support better visibility, minimise delays, and keep your deliveries running smoothly.</p>
               <div class="aff-planning-actions">
                 <a href="/#contact" target="_blank" class="btn-aff-light-outline">Request a Demo</a>
               </div>
@@ -912,7 +913,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/extension-privacy.html
+++ b/extension-privacy.html
@@ -191,7 +191,7 @@
             <a href="#" id="open_preferences_center">Terms and Conditions</a>
           </div>
           <div class="col-12 text-center mt-3">
-            <p>&copy; 2025 FleetYes. All rights reserved.</p>
+            <p>&copy; 2026 FleetYes. All rights reserved.</p>
           </div>
         </div>
       </div>

--- a/feature/ai-receipt-recognition.html
+++ b/feature/ai-receipt-recognition.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/background-location-tracking.html
+++ b/feature/background-location-tracking.html
@@ -842,7 +842,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/calendar-scheduling.html
+++ b/feature/calendar-scheduling.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/compliance-engine.html
+++ b/feature/compliance-engine.html
@@ -842,7 +842,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/dark-mode-customisable-themes.html
+++ b/feature/dark-mode-customisable-themes.html
@@ -796,7 +796,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/driver-management.html
+++ b/feature/driver-management.html
@@ -850,7 +850,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/driver-operations.html
+++ b/feature/driver-operations.html
@@ -816,7 +816,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/driver-profile-documents.html
+++ b/feature/driver-profile-documents.html
@@ -810,7 +810,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/expense-receipt-management.html
+++ b/feature/expense-receipt-management.html
@@ -824,7 +824,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/fuel-tracking.html
+++ b/feature/fuel-tracking.html
@@ -826,7 +826,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/google-maps-navigation.html
+++ b/feature/google-maps-navigation.html
@@ -806,7 +806,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/gps-navigation-route-tracking.html
+++ b/feature/gps-navigation-route-tracking.html
@@ -812,7 +812,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/image-processing.html
+++ b/feature/image-processing.html
@@ -842,7 +842,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/import-hub.html
+++ b/feature/import-hub.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/internationalisation-localisation.html
+++ b/feature/internationalisation-localisation.html
@@ -810,7 +810,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/issue-reporting.html
+++ b/feature/issue-reporting.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/leave-management.html
+++ b/feature/leave-management.html
@@ -805,7 +805,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/ml-kit-text-recognition.html
+++ b/feature/ml-kit-text-recognition.html
@@ -834,7 +834,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/offline-first-architecture.html
+++ b/feature/offline-first-architecture.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/operational-dashboard.html
+++ b/feature/operational-dashboard.html
@@ -818,7 +818,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/org-settings-permissions.html
+++ b/feature/org-settings-permissions.html
@@ -808,7 +808,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/passwordless-otp-authentication.html
+++ b/feature/passwordless-otp-authentication.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/push-notifications-real-time-updates.html
+++ b/feature/push-notifications-real-time-updates.html
@@ -816,7 +816,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/real-time-order-management.html
+++ b/feature/real-time-order-management.html
@@ -810,7 +810,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/rota-scheduling.html
+++ b/feature/rota-scheduling.html
@@ -816,7 +816,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/shift-leave-management.html
+++ b/feature/shift-leave-management.html
@@ -824,7 +824,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/toll-expense-tracking.html
+++ b/feature/toll-expense-tracking.html
@@ -824,7 +824,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/training-compliance.html
+++ b/feature/training-compliance.html
@@ -840,7 +840,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/trip-management.html
+++ b/feature/trip-management.html
@@ -816,7 +816,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/vehicle-inspection.html
+++ b/feature/vehicle-inspection.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/feature/vehicle-management.html
+++ b/feature/vehicle-management.html
@@ -832,7 +832,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/features.html
+++ b/features.html
@@ -586,7 +586,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -727,7 +727,7 @@ Tell us about your transport operation and we’ll show you how FleetYes can hel
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -224,7 +224,7 @@
             <a href="#" id="open_preferences_center">Terms and Conditions</a>
           </div>
           <div class="col-12 text-center mt-3">
-            <p>&copy; 2025 FleetYes. All rights reserved.</p>
+            <p>&copy; 2026 FleetYes. All rights reserved.</p>
           </div>
         </div>
       </div>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -221,7 +221,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/vas-provider.html
+++ b/vas-provider.html
@@ -655,7 +655,7 @@
           <a href="#" id="open_preferences_center">Terms and Conditions</a>
         </div>
         <div class="col-12 text-center mt-3">
-          <p>&copy; 2025 FleetYes. All rights reserved.</p>
+          <p>&copy; 2026 FleetYes. All rights reserved.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Bump copyright year from 2025 to 2026 across the site (HTML pages and ReadMe). Update assets/css/main.css to use Open Sans as the default font while retaining Marcellus as the --heading-font. Large refactor in aff.html: replace hardcoded font declarations with CSS variables, adjust typography (sizes, weights, line-heights), swap several color usages to variable-based colors, and refine AFF planning card copy; also update the header demo link to #book. Minor polish to form/control styles and spacing to align with the variable-based theme.