### PR TITLE
Fix: Add Turnstile and AJAX submit for AFF form

### DIFF
--- a/aff.html
+++ b/aff.html
@@ -21,6 +21,9 @@
   <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet" />
   <link href="assets/vendor/aos/aos.css" rel="stylesheet" />
 
+  <!-- Cloudflare Turnstile -->
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+
   <!-- Main CSS -->
   <link href="assets/css/main.css" rel="stylesheet" />
 
@@ -207,7 +210,7 @@
       max-width: 460px;
       color: #cbd2cf;
       font-size: 15px;
-      font-weight: 700;
+      font-weight: 600;
       line-height: 1.7;
       margin-bottom: 32px;
     }
@@ -265,6 +268,7 @@
       font-family: var(--heading-font);
       font-size: 84px;
       letter-spacing: 0.04em;
+      font-weight: 500;
       color: rgba(255,255,255,0.92);
       line-height: 1;
     }
@@ -853,7 +857,7 @@
           </div>
 
           <div class="col-lg-7" data-aos="fade-up" data-aos-delay="100">
-            <form id="aff-meeting-form" action="/mail/send/index.php" method="post" class="aff-form" aria-label="AFF 2026 meeting form" novalidate>
+            <form id="aff-meeting-form" action="#" method="post" class="aff-form" aria-label="AFF 2026 meeting form" novalidate>
               <div class="row g-3">
                 <div class="col-md-6">
                   <input type="text" name="full-name" class="form-control" placeholder="Full Name" required aria-label="Full Name" />
@@ -887,6 +891,14 @@
                 </div>
                 <div class="col-12">
                   <textarea name="message" class="form-control" rows="4" placeholder="How can we help you?" aria-label="How can we help you?"></textarea>
+                </div>
+                <div class="col-12">
+                  <div class="cf-turnstile" data-sitekey="0x4AAAAAADAXF6RcnPhp25XQ" data-theme="light"></div>
+                </div>
+                <div class="col-12">
+                  <div class="aff-form-loading" aria-live="polite" style="display:none;">Sending…</div>
+                  <div class="aff-form-error" aria-live="polite" style="display:none;color:#b00020;margin-top:8px;"></div>
+                  <div class="aff-form-sent" aria-live="polite" style="display:none;color:var(--aff-green);margin-top:8px;">Thanks — your request has been sent. We'll be in touch shortly.</div>
                 </div>
                 <div class="col-md-6 col-12">
                   <button type="submit" class="btn-aff-submit">Let’s Talk Logistics</button>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -307,6 +307,80 @@ document.querySelectorAll('.faq-item h3, .faq-item .faq-toggle').forEach((faqIte
     });
   }
 })();
+
+(() => {
+  "use strict";
+
+  const form = document.querySelector("#aff-meeting-form");
+  if (!form) return;
+
+  const loading = form.querySelector(".aff-form-loading");
+  const errorMessage = form.querySelector(".aff-form-error");
+  const sentMessage = form.querySelector(".aff-form-sent");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    if (!form.checkValidity()) {
+      event.stopPropagation();
+      form.classList.add("was-validated");
+      return;
+    }
+
+    errorMessage.style.display = "none";
+    sentMessage.style.display = "none";
+    loading.style.display = "block";
+
+    try {
+      const turnstileToken = form.querySelector('[name="cf-turnstile-response"]')?.value;
+      if (!turnstileToken) {
+        throw new Error("Please complete the security check.");
+      }
+
+      const formData = new FormData(form);
+      const data = {
+        source: "aff",
+        fullName: formData.get("full-name"),
+        companyName: formData.get("company-name"),
+        email: formData.get("email"),
+        phone: formData.get("phone"),
+        fleetSize: formData.get("fleet-size"),
+        role: formData.get("role"),
+        message: formData.get("message"),
+        turnstileToken,
+      };
+
+      const response = await fetch("/mail/send/index.php", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "token": "zQew5L8ZHQb4VkBoEXM6JEtKw7WXByQVAzBccYRF76VBKpQVDbsrTw4gPDAo148K",
+        },
+        body: JSON.stringify(data),
+      });
+
+      loading.style.display = "none";
+
+      if (response.ok) {
+        sentMessage.style.display = "block";
+        form.reset();
+        form.classList.remove("was-validated");
+        if (window.turnstile) window.turnstile.reset();
+      } else {
+        const responseData = await response.json().catch(() => ({}));
+        errorMessage.style.display = "block";
+        errorMessage.textContent =
+          responseData.message || "Failed to send your request.";
+      }
+    } catch (error) {
+      loading.style.display = "none";
+      errorMessage.style.display = "block";
+      errorMessage.textContent =
+        "An error occurred while sending your request. " + error.message;
+      console.error(error);
+    }
+  });
+})();
   /**
    * AI Features Slider is now handled by Swiper (see HTML for config)
    */


### PR DESCRIPTION
Integrate Cloudflare Turnstile into the AFF meeting form and switch to an AJAX-based submission flow. aff.html: include Turnstile script, add the Turnstile widget, form status messages, and tweak some heading/paragraph font-weights; change the form action to prevent direct submission. assets/js/main.js: add client-side submit handler that validates the form, requires the Turnstile token, sends form data as JSON to the mail endpoint, shows loading/error/success states, and resets the Turnstile widget on success. Also adds an auth header for the mail API request.