### PR TITLE
Refact: Rename AFF to Amazon FastForward and tweak hero

### DIFF
--- a/aff.html
+++ b/aff.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title>AFF Event 2026 – FleetYes</title>
-  <meta name="description" content="Join FleetYes, an officially recognised Amazon AFP Value Added Service (VAS) Provider, at the AFF Event 2026 in Rome, Italy. 26-28 May 2026." />
+  <meta name="description" content="Join FleetYes, an officially recognised Amazon AFP Value Added Service (VAS) Provider, at the Amazon FastForward Event 2026 in Rome, Italy. 26-28 May 2026." />
 
   <!-- Favicons -->
   <link href="assets/img/fleetyes.svg" rel="icon" />
@@ -175,13 +175,17 @@
       font-size: 54px;
       line-height: 1.05;
       color: #fff;
-      margin-bottom: 10px;
+      margin-bottom: 18px;
       font-weight: 400;
+      max-width: 560px;
     }
     .aff-hero h1 .accent {
       display: block;
       color: var(--aff-green-lt);
-      font-size: 44px;
+      font-size: 38px;
+      line-height: 1.18;
+      letter-spacing: -0.005em;
+      margin-top: 6px;
     }
     .aff-hero-meta {
       display: flex;
@@ -266,7 +270,7 @@
     }
     .aff-hero-watermark .aff-wm-title {
       font-family: var(--heading-font);
-      font-size: 84px;
+      font-size: 54px;
       letter-spacing: 0.04em;
       font-weight: 500;
       color: rgba(255,255,255,0.92);
@@ -622,8 +626,8 @@
       .aff-hero-watermark { display: none; }
     }
     @media (max-width: 991px) {
-      .aff-hero h1 { font-size: 42px; }
-      .aff-hero h1 .accent { font-size: 32px; }
+      .aff-hero h1 { font-size: 42px; max-width: 100%; }
+      .aff-hero h1 .accent { font-size: 30px; }
       .aff-hero-inner { padding: 110px 0 70px; }
       .aff-about, .aff-gift, .aff-planning, .aff-contact { padding: 60px 0; }
       .aff-about h2,
@@ -635,7 +639,7 @@
     }
     @media (max-width: 767px) {
       .aff-hero h1 { font-size: 34px; }
-      .aff-hero h1 .accent { font-size: 26px; }
+      .aff-hero h1 .accent { font-size: 24px; }
       .aff-hero-inner { padding: 100px 0 60px; }
       .aff-hero-meta { gap: 14px; }
       .aff-hero-desc { font-size: 14px; }
@@ -654,7 +658,7 @@
     }
     @media (max-width: 480px) {
       .aff-hero h1 { font-size: 28px; }
-      .aff-hero h1 .accent { font-size: 22px; }
+      .aff-hero h1 .accent { font-size: 20px; }
       .aff-hero-actions { flex-direction: column; }
       .aff-hero-actions a { width: 100%; justify-content: center; }
       .aff-planning-actions { flex-direction: column; }
@@ -702,7 +706,7 @@
               </span>
               <h1>
                 JOIN US
-                <span class="accent">at the AFF Event 2026</span>
+                <span class="accent">at the Amazon FastForward Event 2026</span>
               </h1>
               <div class="aff-hero-meta">
                 <div class="aff-hero-meta-item">
@@ -729,8 +733,7 @@
       </div>
 
       <div class="aff-hero-watermark d-none d-xl-block">
-        <div class="aff-wm-title">AFF</div>
-        <div class="aff-wm-sub">Amazon Freight Partner</div>
+        <div class="aff-wm-title">Amazon FastForward</div>
         <div class="aff-wm-year">EVENT 2026</div>
       </div>
     </section>
@@ -742,10 +745,10 @@
         <div class="row gy-5 align-items-start">
           <div class="col-lg-6" data-aos="fade-up">
             <div class="aff-eyebrow">About the Event</div>
-            <h2>Connecting with Amazon Freight Partners Across Europe</h2>
-            <p>The AFF Event 2026 is an annual gathering for Amazon Freight Partner operators and the wider ecosystem of technology providers supporting AFP operations.</p>
+            <h2>Connecting with Amazon Freight Partners and Relay Carriers Across Europe</h2>
+            <p>The Amazon Freight Partner Event 2026 is an annual gathering for Amazon Freight Partner operators and the wider ecosystem of technology providers supporting AFP operations.</p>
             <p>As an officially recognised Amazon AFP Value Added Service (VAS) Provider, <strong>FleetYes</strong> will be attending to connect with transport operators, discuss operational challenges, and demonstrate how our platform helps logistics teams improve visibility, reduce manual coordination, and manage fleet operations more efficiently.</p>
-            <p>Whether you're looking to improve driver compliance, streamline dispatch operations, or gain better operational control across your delivery network, we'd love to meet you at the event.</p>
+            <p>Whether you're looking to improve driver compliance, claim tolls more efficiently, reconcile fuel and toll transactions, or automate load allocation to drivers using AI, we'd love to meet you at the event and show how FleetYes supports smarter AFP and RSP operations.</p>
           </div>
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
             <div class="aff-info-card">
@@ -756,8 +759,8 @@
                 </div>
                 <div class="aff-info-body">
                   <div class="aff-info-label">What</div>
-                  <div class="aff-info-title">AFF Event 2026</div>
-                  <p class="aff-info-desc">The AFF Event is an annual gathering for Amazon Freight Partner operators and their ecosystem of technology providers.</p>
+                  <div class="aff-info-title">Amazon Freight Partners Event 2026</div>
+                  <p class="aff-info-desc">An opportunity for Amazon Freight Partners to explore operational solutions, connect with technology providers, and discover tools that improve fleet efficiency, compliance, and delivery performance.</p>
                 </div>
               </div>
 
@@ -768,7 +771,7 @@
                 <div class="aff-info-body">
                   <div class="aff-info-label">When</div>
                   <div class="aff-info-title">26 – 28 May 2026</div>
-                  <p class="aff-info-desc">An event bringing together Amazon Freight Partners and their technology providers. A great opportunity to connect, learn and explore solutions that support AFP operations.</p>
+                  <p class="aff-info-desc">An event bringing together Amazon Freight Partners and their technology providers. A great opportunity to connect, learn and explore solutions that support AFP and RSP operations.</p>
                 </div>
               </div>
 
@@ -795,10 +798,10 @@
       <div class="container">
         <div class="aff-gift-card" data-aos="fade-up">
           <div class="aff-gift-emoji" aria-hidden="true">🎁</div>
-          <div class="aff-gift-eyebrow">Collect Your AFF Giveaway</div>
+          <div class="aff-gift-eyebrow">Collect Your Amazon FastForward Giveaway</div>
           <h2>Stop by the FleetYes Booth for Live Platform Demos and Event Gifts</h2>
-          <p>Stop by the FleetYes booth during AFF Event 2026 to meet our team, explore the platform in action, and receive an exclusive attendee gift.</p>
-          <p>Discover how FleetYes helps Amazon Freight Partners improve fleet visibility, simplify delivery operations, and reduce operational bottlenecks across daily transport workflows.</p>
+          <p>Stop by the FleetYes booth during Amazon FastForward Event 2026 to meet our team, explore the platform in action, and receive an exclusive gift.</p>
+          <p>Discover how FleetYes helps Carrier improve fleet visibility, simplify delivery operations, and reduce operational bottlenecks across daily transport workflows.</p>
         </div>
       </div>
     </section>
@@ -813,9 +816,9 @@
           </div>
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
             <div class="aff-planning-card">
-              <div class="aff-eyebrow">MEET US AT AFF 2026</div>
+              <div class="aff-eyebrow">MEET US AT Amazon FastForward 2026</div>
               <h2>Let’s talk fleet operations</h2>
-              <p>Heading to Rome for AFF 2026? We would be delighted to sit down with you. Schedule a brief chat with the FleetYes team to discuss your day-to-day operational hurdles, and let's explore how our platform can support better visibility, minimise delays, and keep your deliveries running smoothly.</p>
+              <p>Heading to Rome for Amazon FastForward 2026? We would be delighted to sit down with you. Schedule a brief chat with the FleetYes team to discuss your day-to-day operational hurdles, and let's explore how our platform can support better visibility, minimise delays, and keep your deliveries with operations running smoothly.</p>
               <div class="aff-planning-actions">
                 <a href="/#contact" target="_blank" class="btn-aff-light-outline">Request a Demo</a>
               </div>
@@ -832,7 +835,7 @@
         <div class="row gy-5 align-items-start">
           <div class="col-lg-5 aff-contact-info" data-aos="fade-up">
             <div class="aff-eyebrow">Book Time with the FleetYes Team</div>
-            <h2>Let's Connect at AFF Event 2026</h2>
+            <h2>Let's Connect at Amazon FastForward Event 2026</h2>
             <p>Complete the form below and a member of our team will contact you to arrange a meeting during the event.</p>
             <ul class="aff-checklist">
               <li>
@@ -845,7 +848,7 @@
                 <span class="check-ico">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6" stroke-linecap="round"/><line x1="8" y1="2" x2="8" y2="6" stroke-linecap="round"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
                 </span>
-                Discover how we help AFP operators improve efficiency and drive results
+                Discover how we help AFP and RSP operations improve efficiency and drive results
               </li>
               <li>
                 <span class="check-ico">
@@ -918,7 +921,7 @@
           <div class="cta-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6" stroke-linecap="round"/><line x1="8" y1="2" x2="8" y2="6" stroke-linecap="round"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
           </div>
-          <span class="cta-text">We look forward to meeting you at AFF Event 2026.</span>
+          <span class="cta-text">We look forward to meeting you at Amazon FastForward Event 2026.</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replace references to "AFF" with the full "Amazon FastForward" event name across the page and update the meta description. Adjust hero typography and spacing (h1 margin, accent font size/line-height/letter-spacing, max-width) and reduce watermark font-size for visual balance. Content copy updated to mention Amazon Freight Partners, Relay/ RSP operations and added clarifying copy for demos, giveaways and booking; minor responsive size tweaks included.