### PR TITLE
Update AFF page copy to include Relay Carriers

### DIFF
--- a/aff.html
+++ b/aff.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title>AFF Event 2026 – FleetYes</title>
-  <meta name="description" content="Join FleetYes, an officially recognised Amazon AFP Value Added Service (VAS) Provider, at the Amazon FastForward Event 2026 in Rome, Italy. 26-28 May 2026." />
+  <meta name="description" content="Join FleetYes, an officially recognised Amazon Value Added Service (VAS) Provider, at the Amazon FastForward Event 2026 in Rome, Italy. 26-28 May 2026." />
 
   <!-- Favicons -->
   <link href="assets/img/fleetyes.svg" rel="icon" />
@@ -747,7 +747,7 @@
             <div class="aff-eyebrow">About the Event</div>
             <h2>Connecting with Amazon Freight Partners and Relay Carriers Across Europe</h2>
             <p>The Amazon Freight Partner Event 2026 is an annual gathering for Amazon Freight Partner operators and the wider ecosystem of technology providers supporting AFP operations.</p>
-            <p>As an officially recognised Amazon AFP Value Added Service (VAS) Provider, <strong>FleetYes</strong> will be attending to connect with transport operators, discuss operational challenges, and demonstrate how our platform helps logistics teams improve visibility, reduce manual coordination, and manage fleet operations more efficiently.</p>
+            <p>As an officially recognised Amazon Value Added Service (VAS) Provider, <strong>FleetYes</strong> will be attending to connect with transport operators, understand operational challenges, and demonstrate how our platform helps logistics teams improve visibility, reduce manual coordination, and manage fleet operations more efficiently.</p>
             <p>Whether you're looking to improve driver compliance, claim tolls more efficiently, reconcile fuel and toll transactions, or automate load allocation to drivers using AI, we'd love to meet you at the event and show how FleetYes supports smarter AFP and RSP operations.</p>
           </div>
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
@@ -759,8 +759,8 @@
                 </div>
                 <div class="aff-info-body">
                   <div class="aff-info-label">What</div>
-                  <div class="aff-info-title">Amazon Freight Partners Event 2026</div>
-                  <p class="aff-info-desc">An opportunity for Amazon Freight Partners to explore operational solutions, connect with technology providers, and discover tools that improve fleet efficiency, compliance, and delivery performance.</p>
+                  <div class="aff-info-title">Amazon Freight Partners and Relay Carriers Event 2026</div>
+                  <p class="aff-info-desc">An opportunity for Amazon Freight Partners and Relay Carriers to explore operational solutions, connect with technology providers, and discover tools that improve fleet efficiency, compliance, and delivery performance.</p>
                 </div>
               </div>
 
@@ -771,7 +771,7 @@
                 <div class="aff-info-body">
                   <div class="aff-info-label">When</div>
                   <div class="aff-info-title">26 – 28 May 2026</div>
-                  <p class="aff-info-desc">An event bringing together Amazon Freight Partners and their technology providers. A great opportunity to connect, learn and explore solutions that support AFP and RSP operations.</p>
+                  <p class="aff-info-desc">An event bringing together Amazon Freight Partners, Relay Carriers and their technology providers. A great opportunity to connect, learn and explore solutions that support AFP and RSP operations.</p>
                 </div>
               </div>
 
@@ -818,7 +818,7 @@
             <div class="aff-planning-card">
               <div class="aff-eyebrow">MEET US AT Amazon FastForward 2026</div>
               <h2>Let’s talk fleet operations</h2>
-              <p>Heading to Rome for Amazon FastForward 2026? We would be delighted to sit down with you. Schedule a brief chat with the FleetYes team to discuss your day-to-day operational hurdles, and let's explore how our platform can support better visibility, minimise delays, and keep your deliveries with operations running smoothly.</p>
+              <p>Heading to Rome for Amazon FastForward 2026? We would be delighted to sit down with you. Schedule a brief chat with the FleetYes team to understand your day-to-day operational hurdles, and let's explore how our platform can support better visibility, minimise delays, and keep your deliveries with operations running smoothly.</p>
               <div class="aff-planning-actions">
                 <a href="/#contact" target="_blank" class="btn-aff-light-outline">Request a Demo</a>
               </div>


### PR DESCRIPTION
Revise copy on aff.html to broaden and clarify the AFF 2026 messaging: remove 'AFP' from the meta description, update the event title and descriptions to include 'Relay Carriers', and replace instances of 'discuss' with 'understand' for a more consultative tone. These are minor content tweaks to ensure inclusivity and improve wording.