### PR TITLE
Rename event to 'Amazon FastForward Event'

### DIFF
--- a/aff.html
+++ b/aff.html
@@ -746,7 +746,7 @@
           <div class="col-lg-6" data-aos="fade-up">
             <div class="aff-eyebrow">About the Event</div>
             <h2>Connecting with Amazon Freight Partners and Relay Carriers Across Europe</h2>
-            <p>The Amazon Freight Partner Event 2026 is an annual gathering for Amazon Freight Partner operators and the wider ecosystem of technology providers supporting AFP operations.</p>
+            <p>The Amazon FastForward Event 2026 is an annual gathering for Amazon Freight Partner operators and the wider ecosystem of technology providers supporting AFP operations.</p>
             <p>As an officially recognised Amazon Value Added Service (VAS) Provider, <strong>FleetYes</strong> will be attending to connect with transport operators, understand operational challenges, and demonstrate how our platform helps logistics teams improve visibility, reduce manual coordination, and manage fleet operations more efficiently.</p>
             <p>Whether you're looking to improve driver compliance, claim tolls more efficiently, reconcile fuel and toll transactions, or automate load allocation to drivers using AI, we'd love to meet you at the event and show how FleetYes supports smarter AFP and RSP operations.</p>
           </div>
@@ -759,7 +759,7 @@
                 </div>
                 <div class="aff-info-body">
                   <div class="aff-info-label">What</div>
-                  <div class="aff-info-title">Amazon Freight Partners and Relay Carriers Event 2026</div>
+                  <div class="aff-info-title">Amazon FastForward Event 2026</div>
                   <p class="aff-info-desc">An opportunity for Amazon Freight Partners and Relay Carriers to explore operational solutions, connect with technology providers, and discover tools that improve fleet efficiency, compliance, and delivery performance.</p>
                 </div>
               </div>


### PR DESCRIPTION
Replace instances of 'Amazon Freight Partner Event 2026' with 'Amazon FastForward Event 2026' in aff.html (about section and the info title) to reflect updated event branding and ensure consistency.